### PR TITLE
ci: upload Jest coverage to Codacy

### DIFF
--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: npm
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload Coverage to Codacy
         if: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
-        uses: codacy/codacy-coverage-reporter-action@v1
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info


### PR DESCRIPTION
- Adds .github/workflows/codacy-coverage.yml
- Runs on pull_request and push to main
- Installs deps with Node 24, runs npm test -- --coverage
- Uploads coverage/lcov.info to Codacy using CODACY_PROJECT_TOKEN
- Upload step is gated so missing secrets in forked PRs won’t fail the workflow
