### PR TITLE
ci(codacy): upload Jest coverage from GitHub Actions with pinned actions

### DIFF
--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -25,9 +28,14 @@ jobs:
       - name: Run Tests with Coverage
         run: npm test -- --coverage
 
+      - name: Verify Coverage Artifact
+        run: test -s coverage/lcov.info
+
       - name: Upload Coverage to Codacy
         if: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info
+          language: JavaScript
+          force-coverage-parser: lcov


### PR DESCRIPTION
## Summary
- Adds a dedicated GitHub Actions workflow to publish coverage to Codacy.
- Generates coverage with Jest and uploads `coverage/lcov.info`.
- Pins all third-party actions to full commit SHAs to satisfy Codacy policy checks.

## Changes
1. Add `.github/workflows/codacy-coverage.yml`
2. Run on:
   - `pull_request`
   - `push` to `main`
3. Use Node 24 + `npm ci`
4. Run tests with coverage:
   - `npm test -- --coverage`
5. Verify coverage artifact exists:
   - `test -s coverage/lcov.info`
6. Upload coverage to Codacy using:
   - `codacy/codacy-coverage-reporter-action`
   - `project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}`
   - `language: JavaScript`
   - `force-coverage-parser: lcov`
7. Ensure PR coverage maps to the correct commit by checking out PR head SHA (not merge SHA).

## Security/Compliance
- All external actions are pinned to immutable full-length commit SHAs.

## Notes
- Upload step runs only when `CODACY_PROJECT_TOKEN` is available.
- This addresses Codacy’s “no coverage configured” signal by ensuring `lcov` is generated and uploaded for the exact commit Codacy analyzes.